### PR TITLE
Replace plugin path with constant

### DIFF
--- a/admin/admin-functions.php
+++ b/admin/admin-functions.php
@@ -92,7 +92,7 @@ function poetwp_enqueue_admin_assets() {
 	wp_enqueue_style( 'jquery-ui-css', 'https://code.jquery.com/ui/1.13.3/themes/base/jquery-ui.css', array(), '1.13.3' );
 
 	// Enqueue the custom admin stylesheet.
-	wp_enqueue_style( 'poetwp-admin-styles', plugin_dir_url( __FILE__ ) . 'css/poetwp-admin.css', array(), '1.0.0' );
+	wp_enqueue_style( 'poetwp-admin-styles', POETWP_URL . 'admin/css/poetwp-admin.css', array(), '1.0.0' );
 }
 
 // Add action to enqueue admin assets.
@@ -106,9 +106,9 @@ add_action( 'admin_enqueue_scripts', 'poetwp_enqueue_admin_assets' );
 function poetwp_enqueue_block_editor_assets() {
 	wp_enqueue_script(
 		'poetwp-admin-script',
-		plugin_dir_url( __FILE__ ) . 'js/poetwp-admin.js',
+		POETWP_URL . 'admin/js/poetwp-admin.js',
 		array( 'wp-blocks', 'wp-dom-ready', 'wp-edit-post' ),
-		filemtime( plugin_dir_path( __FILE__ ) . 'js/poetwp-admin.js' ),
+		filemtime( POETWP_DIR . 'admin/js/poetwp-admin.js' ),
 		true
 	);
 }

--- a/poetwp.php
+++ b/poetwp.php
@@ -29,17 +29,25 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+if ( ! defined( 'POETWP_DIR' ) ) {
+	define( 'POETWP_DIR', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'POETWP_URL' ) ) {
+	define( 'POETWP_URL', plugin_dir_url( __FILE__ ) );
+}
+
 // Include the file that defines the custom post type functions.
-require_once plugin_dir_path( __FILE__ ) . 'includes/post-type-functions.php';
+require_once POETWP_DIR . 'includes/post-type-functions.php';
 
 // Include the file that creates demo poem.
-require_once plugin_dir_path( __FILE__ ) . 'includes/demo-poem.php';
+require_once POETWP_DIR . 'includes/demo-poem.php';
 
 // Include the file that defines the admin functions.
-require_once plugin_dir_path( __FILE__ ) . 'admin/admin-functions.php';
+require_once POETWP_DIR . 'admin/admin-functions.php';
 
 // Include the file that defines the public functions.
-require_once plugin_dir_path( __FILE__ ) . 'public/public-functions.php';
+require_once POETWP_DIR . 'public/public-functions.php';
 
 // Register activation hook.
 register_activation_hook( __FILE__, 'poetwp_activate' );

--- a/public/public-functions.php
+++ b/public/public-functions.php
@@ -14,7 +14,7 @@
  * @return void
  */
 function poetwp_enqueue_public_styles() {
-	wp_enqueue_style( 'poetwp-public-styles', plugin_dir_url( __FILE__ ) . 'css/poetwp-public.css', array(), '1.0.0', 'all' );
+	wp_enqueue_style( 'poetwp-public-styles', POETWP_URL . 'public/css/poetwp-public.css', array(), '1.0.0', 'all' );
 }
 
 // Add action to enqueue public styles.


### PR DESCRIPTION
Provides an easy way to reference the plugin paths throughout the plugin code and helps prevent errors that might occur from manually typing out paths in multiple locations.

Resolves #22