### PR TITLE
Add deactivate and uninstall cleanup process

### DIFF
--- a/includes/class-demo-poem.php
+++ b/includes/class-demo-poem.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Demo poem class.
+ *
+ * @link       https://nataliesmith.dev
+ * @since      1.0.0
+ * @package    Poetwp\Includes
+ */
+
+/**
+ * Represents a demo poem with a predefined title, status, and type.
+ *
+ * The `Demo_Poem` class provides static methods to retrieve the content and custom fields for a demo poem.
+ */
+class Demo_Poem {
+	/**
+	 * The title of the demo poem.
+	 *
+	 * @var string
+	 */
+	public static $post_title = 'Demo Poem: Windswept';
+
+	/**
+	 * The status of the demo poem.
+	 *
+	 * @var string
+	 */
+	public static $post_status = 'draft';
+
+	/**
+	 * The post type of the demo poem.
+	 *
+	 * @var string
+	 */
+	public static $post_type = 'poem';
+
+	/**
+	 * Get the content of the demo poem.
+	 *
+	 * @return string The content of the demo poem.
+	 */
+	public static function get_content() {
+		return '
+            <!-- wp:verse {"className":"is-style-no-padding","backgroundColor":"base-3"} -->
+        <pre class="wp-block-verse is-style-no-padding has-base-3-background-color has-background">          The wind sweeps  <br>across the open plain,  <br>        bending the grass  <br>                      in a silent refrain,  <br>               where every blade  <br>          dances to a song  <br>                    older than time.</pre>
+        <!-- /wp:verse -->
+
+        <!-- wp:paragraph -->
+        <p>Underneath the sky’s vast dome,  <br>where clouds gather and disperse,  <br>I find a home in the rhythm of the earth,  <br>in the heartbeat of the land.</p>
+        <!-- /wp:paragraph -->
+
+        <!-- wp:verse {"className":"is-style-no-padding","backgroundColor":"base-3"} -->
+        <pre class="wp-block-verse is-style-no-padding has-base-3-background-color has-background">          Trees stand tall,  <br>                    their roots deep,  <br>          whispering secrets  <br>               they vow to keep.  <br>     Leaves flutter  <br>              in a gentle sigh,  <br>     as the day bows  <br>          to the evening sky.</pre>
+        <!-- /wp:verse -->
+
+        <!-- wp:paragraph -->
+        <p>In the hush of twilight, the world grows still,  <br>cradled by the hills and the promise of night.  <br>Stars awaken, one by one,  <br>stitching the sky with threads of light.</p>
+        <!-- /wp:paragraph -->
+
+        <!-- wp:verse {"className":"is-style-no-padding","backgroundColor":"base-3"} -->
+        <pre class="wp-block-verse is-style-no-padding has-base-3-background-color has-background">          In nature’s embrace,  <br>               I find my place,  <br>      between the wild wind’s soft caress  <br>               and the steady pulse  <br>                         of the earth’s quiet grace.</pre>
+        <!-- /wp:verse -->s
+        ';
+	}
+	/**
+	 * Get custom fields for the demo poem.
+	 *
+	 * @return array An array of custom fields for the demo poem.
+	 */
+	public static function get_custom_fields() {
+		return array(
+			'poem_date'  => '2024-08-25',
+			'poem_notes' => '<p>The poem Windswept invites readers to find balance and harmony in the natural world, recognizing both the wild, untamed forces and the steady, grounding elements that coexist.</p><p>By combining unusual and regular alignment, the poem visually and thematically represents this duality, encouraging a deeper appreciation for the beauty and complexity of nature.</p>',
+		);
+	}
+}

--- a/includes/demo-poem.php
+++ b/includes/demo-poem.php
@@ -18,7 +18,7 @@ function poetwp_create_demo_poem() {
 		array(
 			'post_type'      => 'poem',
 			'post_status'    => 'any',
-			'title'          => 'Demo Poem',
+			'title'          => 'Demo Poem: Windswept',
 			'posts_per_page' => 1,
 		)
 	);

--- a/includes/demo-poem.php
+++ b/includes/demo-poem.php
@@ -8,6 +8,11 @@
  */
 
 /**
+ * Includes the Demo Poem class file.
+ */
+require_once POETWP_DIR . 'includes/class-demo-poem.php';
+
+/**
  * Create a demo poem post with Gutenberg blocks and custom fields.
  *
  * @return void
@@ -16,9 +21,9 @@ function poetwp_create_demo_poem() {
 	// Check if the demo poem already exists.
 	$existing_poem = new WP_Query(
 		array(
-			'post_type'      => 'poem',
+			'post_type'      => Demo_Poem::$post_type,
 			'post_status'    => 'any',
-			'title'          => 'Demo Poem: Windswept',
+			'title'          => Demo_Poem::$post_title,
 			'posts_per_page' => 1,
 		)
 	);
@@ -26,35 +31,13 @@ function poetwp_create_demo_poem() {
 	if ( $existing_poem->have_posts() ) {
 		return;
 	}
-	// Prepare the poem content with Gutenberg blocks.
-	$poem_content = '
-	<!-- wp:verse {"className":"is-style-no-padding","backgroundColor":"base-3"} -->
-	<pre class="wp-block-verse is-style-no-padding has-base-3-background-color has-background">          The wind sweeps  <br>across the open plain,  <br>        bending the grass  <br>                      in a silent refrain,  <br>               where every blade  <br>          dances to a song  <br>                    older than time.</pre>
-	<!-- /wp:verse -->
-
-	<!-- wp:paragraph -->
-	<p>Underneath the sky’s vast dome,  <br>where clouds gather and disperse,  <br>I find a home in the rhythm of the earth,  <br>in the heartbeat of the land.</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:verse {"className":"is-style-no-padding","backgroundColor":"base-3"} -->
-	<pre class="wp-block-verse is-style-no-padding has-base-3-background-color has-background">          Trees stand tall,  <br>                    their roots deep,  <br>          whispering secrets  <br>               they vow to keep.  <br>     Leaves flutter  <br>              in a gentle sigh,  <br>     as the day bows  <br>          to the evening sky.</pre>
-	<!-- /wp:verse -->
-
-	<!-- wp:paragraph -->
-	<p>In the hush of twilight, the world grows still,  <br>cradled by the hills and the promise of night.  <br>Stars awaken, one by one,  <br>stitching the sky with threads of light.</p>
-	<!-- /wp:paragraph -->
-
-	<!-- wp:verse {"className":"is-style-no-padding","backgroundColor":"base-3"} -->
-	<pre class="wp-block-verse is-style-no-padding has-base-3-background-color has-background">          In nature’s embrace,  <br>               I find my place,  <br>      between the wild wind’s soft caress  <br>               and the steady pulse  <br>                         of the earth’s quiet grace.</pre>
-	<!-- /wp:verse -->
-	';
 
 	// Set up the poem post data.
 	$poem_data = array(
-		'post_title'   => 'Demo Poem: Windswept',
-		'post_content' => $poem_content,
-		'post_status'  => 'draft',
-		'post_type'    => 'poem',
+		'post_title'   => Demo_Poem::$post_title,
+		'post_content' => Demo_Poem::get_content(),
+		'post_status'  => Demo_Poem::$post_status,
+		'post_type'    => Demo_Poem::$post_type,
 	);
 
 	// Insert the poem post into the database.
@@ -62,7 +45,9 @@ function poetwp_create_demo_poem() {
 
 	// Add custom fields to the poem post.
 	if ( $poem_id ) {
-		update_post_meta( $poem_id, 'poem_date', '2024-08-25' );
-		update_post_meta( $poem_id, 'poem_notes', '<p>The poem Windswept invites readers to find balance and harmony in the natural world, recognizing both the wild, untamed forces and the steady, grounding elements that coexist.</p><p>By combining unusual and regular alignment, the poem visually and thematically represents this duality, encouraging a deeper appreciation for the beauty and complexity of nature.</p>' );
+		$custom_fields = Demo_Poem::get_custom_fields();
+		foreach ( $custom_fields as $key => $value ) {
+			update_post_meta( $poem_id, $key, $value );
+		}
 	}
 }

--- a/poetwp.php
+++ b/poetwp.php
@@ -66,3 +66,18 @@ function poetwp_activate() {
 	// Create demo poem.
 	poetwp_create_demo_poem();
 }
+
+// Register deactivation hook.
+register_deactivation_hook( __FILE__, 'poetwp_deactivate' );
+
+/**
+ * Deactivation function for the plugin.
+ * This function removes the custom 'poem' post type and flushes the rewrite rules.
+ */
+function poetwp_deactivate() {
+	// Remove the custom post type.
+	unregister_post_type( 'poem' );
+
+	// Flush rewrite rules.
+	flush_rewrite_rules();
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * @link       https://nataliesmith.dev
+ * @since      1.0.0
+ * @package    Poetwp
+ */
+
+// If uninstall not called from WordPress, then exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+/**
+ * Deletes all poems from the database when the plugin is uninstalled.
+ */
+$args = array(
+	'post_type'      => 'poem',
+	'posts_per_page' => -1,
+	'post_status'    => 'any',
+);
+
+$poems = get_posts( $args );
+
+foreach ( $poems as $poem ) {
+	wp_delete_post( $poem->ID, true );
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,16 +13,17 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 /**
- * Deletes all poems from the database when the plugin is uninstalled.
+ * Deletes demo from the database when the plugin is uninstalled.
  */
 $args = array(
 	'post_type'      => 'poem',
-	'posts_per_page' => -1,
 	'post_status'    => 'any',
+	'title'          => 'Demo Poem: Windswept',
+	'posts_per_page' => 1,
 );
 
-$poems = get_posts( $args );
+$demo_poem = get_posts( $args );
 
-foreach ( $poems as $poem ) {
-	wp_delete_post( $poem->ID, true );
+if ( ! empty( $demo_poem ) ) {
+	wp_delete_post( $demo_poem[0]->ID, true );
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,12 +13,22 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 /**
+ * Includes the main file.
+ */
+require_once 'poetwp.php';
+
+/**
+ * Includes the Demo Poem class file.
+ */
+require_once POETWP_DIR . 'includes/class-demo-poem.php';
+
+/**
  * Deletes demo from the database when the plugin is uninstalled.
  */
 $args = array(
-	'post_type'      => 'poem',
+	'post_type'      => Demo_Poem::$post_type,
 	'post_status'    => 'any',
-	'title'          => 'Demo Poem: Windswept',
+	'title'          => Demo_Poem::$post_title,
 	'posts_per_page' => 1,
 );
 


### PR DESCRIPTION
1. Updated poetwp.php:

- Added a deactivation hook using register_deactivation_hook().
- Implemented the poetwp_deactivate() function, which:
  - Removes the custom 'poem' post type using unregister_post_type().
  - Flushes rewrite rules using flush_rewrite_rules().

2. Added uninstall.php:

* This file handles the plugin uninstallation process.
* It deletes all poems (custom post type 'poem') from the database when the plugin is uninstalled.
* It uses get_posts() to retrieve all poems and wp_delete_post() to remove them.

Resolves #20 