### PR TITLE
Licence: Fix SPDX reference

### DIFF
--- a/poetwp.php
+++ b/poetwp.php
@@ -18,7 +18,7 @@
  * Version:           1.0.0
  * Author:            Natalie Smith
  * Author URI:        https://nataliesmith.dev/
- * License:           GPL-2.0+
+ * License:           GPL-2.0-or-later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Text Domain:       poetwp
  * Domain Path:       /languages


### PR DESCRIPTION
The "GPL v2 or later" licence SPDX code changed a few years ago from GPL-2.0+ to GPL-2.0-or-later. See https://spdx.org/licenses/GPL-2.0-or-later.html